### PR TITLE
Bump jq version to `1.8.1-3` for `1877`

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,15 +1,15 @@
 pkg=jq
-version_orig=1.7.1-6
-version="$version_orig-0"
-git_src -b "debian/$version_orig" https://salsa.debian.org/debian/jq.git
+version_orig=1.8.1
+version="$version_orig-3"
+git_src -b "debian/$version" https://salsa.debian.org/debian/jq.git
 
-version_suffix=gl0~bp1877
+version_suffix=gl0+bp1877
 
 apply_patches debian_fixes
 
 
 tee $dir/src/debian/changelog << EOF
-jq (${version_orig}${version_suffix}) unstable; urgency=medium
+jq (${version}${version_suffix}) unstable; urgency=medium
 
   * Manually added patch https://github.com/jqlang/jq/commit/5e159b34b179417e3e0404108190a2ac7d65611c
     (Fix GHSA-f946-j5j2-4w5m stack-overflow by limit regex parse depth, Fixes CVE-2025-48060)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps "jq" to version `1.8.1-3` for GardenLinux release `1877.2`.

**Which issue(s) this PR fixes**:
Related: https://github.com/gardenlinux/gardenlinux/issues/3197